### PR TITLE
View 部分 etpl功能优化

### DIFF
--- a/src/View.js
+++ b/src/View.js
@@ -88,6 +88,11 @@ define(function (require) {
 
         // 新建模版引擎
         var tplEngine = new etpl.Engine();
+
+        // 拷贝etpl命名空间的filter、配置
+        tplEngine.options = etpl.options;
+        tplEngine.filters = etpl.filters;
+
         // 保存默认render
         var defaultRender = tplEngine.compile(str);
         // 保存原始的render


### PR DESCRIPTION
视图初始化之前所创建的rtpl实例 `tplEngine = new etpl.Engine()` 清空了开发者注册的 `修改器` 以及 `options` 配置，并且没有机会注入。

现在 new 实例的同时，主动 copy etpl 所拥有的部分配置。
